### PR TITLE
Install dependencies for GitHub Actions to compile

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install ncurses
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libncursesw5-dev libncurses5-dev
     - uses: actions/checkout@v2
     - name: make
       run: make


### PR DESCRIPTION
Install dependencies for GitHub Actions to compile.
Default image does not contain the libs already
